### PR TITLE
Adjust JSON quote symbol

### DIFF
--- a/doc_source/securityhub-cwe-event-formats.md
+++ b/doc_source/securityhub-cwe-event-formats.md
@@ -19,7 +19,7 @@ The EventBridge event for the **Security Hub Findings \- Imported** event type i
       "arn:aws:securityhub:us-west-2::product/aws/macie/arn:aws:macie:us-west-2:111122223333:integtest/trigger/6294d71b927c41cbab915159a8f326a3/alert/f2893b211841"
    ],
    "detail":{
-      "findings”: [AMAZON_FINDING_JSON]
+      "findings": [AMAZON_FINDING_JSON]
    }
 }
 ```


### PR DESCRIPTION
The quote was of the wrong format causing the JSON to not be valid. I've updated it to match the format expected.