### PR TITLE
Corrected link

### DIFF
--- a/doc_source/rds-controls.md
+++ b/doc_source/rds-controls.md
@@ -1192,7 +1192,7 @@ To change the administrative username associated with an RDS database instance, 
 
 **Resource type:** `AWS::RDS::DBInstance`
 
-**AWS Config rule:** [https://docs.aws.amazon.com/config/latest/developerguide/rds-resources-protected-by-backup-plan.html](https://docs.aws.amazon.com/config/latest/developerguide/rds-resources-protected-by-backup-plan.html) ``
+**AWS Config rule:** [https://docs.aws.amazon.com/config/latest/developerguide/\.html](rds-resources-protected-by-backup-plan) ``
 
 **Schedule type:** Periodic
 


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
Link anchor for  rds-resources-protected-by-backup-plan was showing .html.  Set it to just 'rds-resources-protected-by-backup-plan'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
